### PR TITLE
fix: incorrect format for date input

### DIFF
--- a/src/helpers/parseValueFromInput.ts
+++ b/src/helpers/parseValueFromInput.ts
@@ -26,7 +26,7 @@ export const parseValueFromInput = (
   }
 
   if (input.type === 'date') {
-    return input.valueAsDate?.toISOString()?.split('T')?.[0] ?? null
+    return input.valueAsDate?.toISOString()?.split?.('T')?.[0] ?? null
   }
 
   return input.value

--- a/src/helpers/parseValueFromInput.ts
+++ b/src/helpers/parseValueFromInput.ts
@@ -26,7 +26,7 @@ export const parseValueFromInput = (
   }
 
   if (input.type === 'date') {
-    return input.valueAsDate?.toISOString().split('T')[0] ?? null
+    return input.valueAsDate?.toISOString()?.split('T')?.[0] ?? null
   }
 
   return input.value

--- a/src/helpers/parseValueFromInput.ts
+++ b/src/helpers/parseValueFromInput.ts
@@ -26,7 +26,7 @@ export const parseValueFromInput = (
   }
 
   if (input.type === 'date') {
-    return input.valueAsDate?.toISOString() ?? null
+    return input.valueAsDate?.toISOString().split('T')[0] ?? null
   }
 
   return input.value


### PR DESCRIPTION
Previously the date was being formatted in `ISO` format, which the date type input does not accept, so the following warning was received and the date input was emptied.

`The specified value "2024-07-09T00:00:00.000Z" does not conform to the required format, "yyyy-MM-dd".`